### PR TITLE
Reduce /srv Disk volume

### DIFF
--- a/packer/mysql57-vagrant.json
+++ b/packer/mysql57-vagrant.json
@@ -15,7 +15,7 @@
                 {
                     "delete_on_termination": false,
                     "device_name": "/dev/sdb",
-                    "volume_size": 50,
+                    "volume_size": 1,
                     "volume_type": "gp2"
                 }
             ],


### PR DESCRIPTION
Currently, you cannot create an EBS volume < 50 GB or amazon will give an error. It's because the snapshot  is 50GB. It might be good to reduce it so smaller volumes can be used. 

I propose to set it to something like 1GB as when I run it, only 163MB is used:

```
[root@ip-192-168-0-206 srv]# df -h /srv
Filesystem      Size  Used Avail Use% Mounted on
/dev/xvdb        50G  163M   50G   1% /srv
```