### PR TITLE
Add DigitalOcean target for PMM2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,9 @@ pmm2-ovf: fetch
 pmm2-ami:
 	packer build -only amazon-ebs packer/pmm2.json
 
+pmm2-digitalocean:
+	packer build -only digitalocean -var 'single_disk=true' packer/pmm2.json
+
 pmm-gcp:
 	packer build -only googlecompute packer/pmm.json
 

--- a/ansible/pmm2/post-build-actions.yml
+++ b/ansible/pmm2/post-build-actions.yml
@@ -25,9 +25,18 @@
 
     # TODO https://jira.percona.com/browse/PMM-4991
     - name: Detect distribution        | Create '/srv/pmm-distribution' file for AMI
-      when: ansible_virtualization_type == "xen" or ansible_virtualization_type == "kvm"
+      when: >
+        ( ansible_virtualization_type == "xen"
+        or ansible_virtualization_type == "kvm" )
+        and ansible_system_vendor != "DigitalOcean"
       copy:
         content: "ami"
+        dest: /srv/pmm-distribution
+
+    - name: Detect distribution        | Create '/srv/pmm-distribution' file for DigitalOcean
+      when: ansible_system_vendor == "DigitalOcean"
+      copy:
+        content: "digitalocean"
         dest: /srv/pmm-distribution
 
     - name: Disable repo               | Disable testing repo for pmm2-client

--- a/ansible/roles/cloud-node/tasks/main.yml
+++ b/ansible/roles/cloud-node/tasks/main.yml
@@ -3,7 +3,7 @@
     - name: Packages                   | Add EPEL repository
       when: ansible_os_family == 'RedHat'
       yum:
-        name: https://dl.fedoraproject.org/pub/epel/7/x86_64/Packages/e/epel-release-7-12.noarch.rpm
+        name: https://dl.fedoraproject.org/pub/epel/7/x86_64/Packages/e/epel-release-7-13.noarch.rpm
         state: installed
 
     - name: Packages                   | Install OS tools

--- a/ansible/roles/cloud-node/tasks/security.yml
+++ b/ansible/roles/cloud-node/tasks/security.yml
@@ -6,8 +6,7 @@
         line: 'PermitRootLogin no'
         state: present
 
-    - name: security                   | Remove percona key
-      lineinfile:
-        dest: /root/.ssh/authorized_keys
-        regexp: '([Pp]acker|[Pp]ercona)'
+    - name: security                   | Remove authorized_keys file
+      file:
+        path: /root/.ssh/authorized_keys
         state: absent

--- a/ansible/roles/lvm-init/tasks/main.yml
+++ b/ansible/roles/lvm-init/tasks/main.yml
@@ -3,19 +3,20 @@
       yum: name=lvm2 state=installed
 
     - name: Data partition             | list
+      when: not single_disk
       shell: ls /dev/sda /dev/sdb /dev/sdc /dev/xvdb | grep -v ^$(pvdisplay -c | grep ':VolGroup00:' | cut -d ':' -f 1 | tr -d '[:space:]' | sed 's/[0-9]$//')$ | grep -v ^$(findmnt -f -n -o SOURCE / | sed 's/[0-9]$//')$ | grep -v ^$(findmnt -f -n -o SOURCE /mnt/resource | sed 's/[0-9]$//')$
       register: available_drives
       failed_when: available_drives.stdout_lines|length != 1
       changed_when: False
 
     - name: Data partition             | Create Volume Group
-      when: enable_lvm == "true"
+      when: enable_lvm == "true" and not single_disk
       lvg:
         vg: DataVG
         pvs: "{{ available_drives.stdout_lines[0] }}"
 
     - name: Data partition             | Create Thin Pool
-      when: enable_lvm == "true"
+      when: enable_lvm == "true" and not single_disk
       register: thin_pool
       failed_when: "thin_pool is failed and 'Sorry, no shrinking of DataLV to 0 permitted' not in thin_pool.msg"
       lvol:
@@ -25,20 +26,21 @@
         opts: --thinpool ThinPool -V 1G
 
     - name: Data partition             | Format LVM
-      when: enable_lvm == "true"
+      when: enable_lvm == "true" and not single_disk
       filesystem:
         fstype: xfs
         dev: /dev/DataVG/DataLV
         opts: -L DATA
 
     - name: Data partition             | Format Device
-      when: enable_lvm != "true"
+      when: enable_lvm != "true" and not single_disk
       filesystem:
         fstype: xfs
         dev: "{{ available_drives.stdout_lines[0] }}"
         opts: -L DATA
 
     - name: Data partition             | Mount
+      when: not single_disk
       mount:
         name: "{{ data_partition }}"
         src: LABEL=DATA
@@ -80,7 +82,7 @@
         - /var/lib/cloud/scripts/per-boot
 
     - name: Data partition             | Auto resize LVM
-      when: enable_lvm == "true"
+      when: enable_lvm == "true" and not single_disk
       template:
         src: resize-xfs-lvm
         dest: /var/lib/cloud/scripts/per-boot/resize-xfs

--- a/ansible/roles/lvm-init/templates/resize-xfs-no-lvm
+++ b/ansible/roles/lvm-init/templates/resize-xfs-no-lvm
@@ -1,3 +1,3 @@
 #!/bin/sh
 set -o errexit
-usr/sbin/xfs_growfs -d {{ data_partition }}
+/usr/sbin/xfs_growfs -d {{ data_partition }}

--- a/ansible/roles/lvm-init/vars/main.yml
+++ b/ansible/roles/lvm-init/vars/main.yml
@@ -2,4 +2,4 @@
     data_partition: "/srv"
     create_admin: "true"
     enable_lvm: "true"
-
+    single_disk: "false"

--- a/files/digitalocean/digitalocean_add_dbaas.py
+++ b/files/digitalocean/digitalocean_add_dbaas.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python
+
+"""
+This script adds DigitalOcean DBaaS instances to a Percona Monitoring and Management 
+(PMM) host running on the local server. Currently only MySQL DBaaS instances are supported.
+"""
+
+from __future__ import print_function
+import os
+import sys
+import argparse
+import pprint
+import requests
+from requests.packages.urllib3.exceptions import InsecureRequestWarning
+from random import choice
+from string import ascii_letters, digits
+
+
+class PmmServer:
+    def __init__(self, baseURL="https://127.0.0.1:443", serverAdminPassword=None):
+        self.baseURL = baseURL
+        self.password = serverAdminPassword
+    
+    def listServices(self):
+        requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
+
+        
+        body = {
+            "service_type": "MYSQL_SERVICE"
+        }
+        endpoint = self.baseURL + "/v1/inventory/Services/List"
+        try:
+            r = requests.post(endpoint, json=body, verify=False, auth=('admin', self.password))
+            r.raise_for_status()
+        except requests.exceptions.HTTPError as e:
+            if r.status_code == 401:
+                print("Invalid PMM admin password.")
+            else:
+                jsonResponse = r.json()
+                print(jsonResponse['error'])
+            sys.exit(1) 
+        except requests.exceptions.RequestException as e:
+            print('Could not connect to PMM instance at {}'.format(self.baseURL))
+            sys.exit(1)
+    
+        return r.json()
+    
+    def addMySQL(self, mysqlInstance):
+        """
+        Given a dict representing a DBaaS MySQL instance, add it to PMM
+        """
+        print("Adding instance {} to PMM...".format(mysqlInstance.name))
+    
+        mysqlInstance.createMonitoringUser()
+        
+        requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
+
+        
+        body = {
+          "add_node": {
+            "node_type": "REMOTE_NODE",
+            "node_name": mysqlInstance.name,
+            "region": mysqlInstance.region
+          },
+          "service_name": mysqlInstance.name,
+          "address": mysqlInstance.address,
+          "port": mysqlInstance.port,
+          "pmm_agent_id": 'pmm-server',
+          "username": mysqlInstance.admin_username,
+          "password": mysqlInstance.admin_password,
+          "qan_mysql_perfschema": True,
+          "skip_connection_check": False,
+          "disable_query_examples": True,
+          "tls": True,
+          "tls_skip_verify": True,
+          "tablestats_group_table_limit": 0
+        }
+        addURL = self.baseURL + "/v1/management/MySQL/Add"
+        try:
+            r = requests.post(addURL, json=body, verify=False, auth=('admin', self.password))
+            r.raise_for_status()
+        except requests.exceptions.HTTPError:
+            jsonResponse = r.json()
+            if r.status_code == 409:
+                # Node/instance already exists
+                print(jsonResponse['error'])
+            else:
+                print(jsonResponse['error'])
+        except Exception as err:
+            print(err)
+    
+        return        
+
+class DbaasInstance:
+
+    def __init__(self, instanceAttributes, pmmServer):
+        self.name = instanceAttributes['name']
+        self.region = instanceAttributes['region']
+        self.address = instanceAttributes['connection']['host']
+        self.port = instanceAttributes['private_connection']['port']
+        self.admin_username = instanceAttributes['private_connection']['user']
+        self.admin_password = instanceAttributes['private_connection']['password']
+        self.engine = instanceAttributes['engine']
+        self.monitored = self.instanceMonitored(pmmServer)
+
+    
+    def generatePassword(self):
+        password = ''.join([choice(ascii_letters + digits)
+                    for n in range(32)])
+        return password
+    
+    def createMonitoringUser(self):
+        self.monitoring_username = 'pmm'
+        self.monitoring_password = self.generatePassword()
+        return
+    
+    def instanceMonitored(self, pmmServer):
+        """
+        Return boolean based on if an instance is monitored according to PMM API
+        """
+        services = pmmServer.listServices()
+        try:
+            mysqlServices = services['mysql']
+        except KeyError:
+            mysqlServices = []
+        if (self.address, self.port) in [ (i['address'], i['port']) for i in mysqlServices]:
+            return True
+        else:
+            return False
+
+
+def getAPIToken():
+    token = os.environ.get('DIGITALOCEAN_API_TOKEN')
+    if not token:
+        token = raw_input("Enter your DigitalOcean API token: ")
+    return token
+
+def getPMMAdminPassword():
+    password = os.environ.get('PMM_ADMIN_PASSWORD')
+    if not password:
+        token = raw_input("Enter the password for the PMM 'admin' user: ")
+    return password
+
+def getDBInstances(token):
+    """
+    Fetch all DBaaS instances from DigitalOcean API
+    """
+    auth_header = {"Authorization": "Bearer {}".format(token)}
+    try:
+        r = requests.get('https://api.digitalocean.com/v2/databases', headers=auth_header)
+        r.raise_for_status()
+    except requests.exceptions.HTTPError as e:
+        if r.status_code == 401:
+            print("Invalid DigitalOcean API token.")
+        else:
+            jsonResponse = r.json()
+            print(jsonResponse['error'])
+        sys.exit(1) 
+    except Exception as err:
+        print(err)  
+        sys.exit(1) 
+    return r.json()['databases']
+
+def promptForDBSelection(instances):
+    """
+    Display list of eligible DBaaS instances and prompt user to enter selection. 
+    Returns list if selected instances.
+    """
+    selectedInstances = []
+    print('Eligible DBaaS instances found:') 
+    for instance in instances:
+        print('- {}'.format(instance.name), end = '')
+        if instance.monitored:
+            print(' (monitored)')
+        else:
+            print('')
+    try:
+        user_input = raw_input('Enter comma-separated list of database names to monitor [all]: ')
+    except (KeyboardInterrupt, EOFError):
+        print('')
+        sys.exit(0)
+    if len(user_input) == 0:
+        selectedInstanceNames = ['all']
+    else:
+        selectedInstanceNames = [ s.strip() for s in user_input.split(',') ]
+    if 'all' in selectedInstanceNames:
+        validInstances = instances
+    else:
+        validInstances = [ i for i in instances if i.name in selectedInstanceNames ]
+    return validInstances
+
+def getPublicIPv4():
+    """
+    Return the public IPv4 address of localhost
+    """
+    try:
+        r = requests.get("http://169.254.169.254/metadata/v1/interfaces/public/0/ipv4/address")
+        r.raise_for_status()
+    except requests.exceptions.HTTPError:
+        jsonResponse = r.json()
+        print(jsonResponse['error'])
+    except Exception as err:
+        print(err)
+    return r.content
+
+def printBanner():
+    print(
+"""
+# This script adds DigitalOcean DBaaS instances to a Percona Monitoring and Management 
+# (PMM) host running on the local server. Currently only MySQL DBaaS instances are supported.
+# 
+# Before attempting to add DBaaS instances, make sure you have logged in to the Percona 
+# Monitoring and Management GUI and set an admin password using this URL:
+# 
+# http://{}/
+#
+# Ensure that PMM is able to connect to your DBaaS instances by adding the PMM server
+# to each database's Trusted Sources list here: https://cloud.digitalocean.com/databases.
+# 
+# This script will prompt for your PMM password and DigitalOcean API token which can 
+# be generated at https://cloud.digitalocean.com/account/api/tokens (read-only permissions
+# are sufficient). You can set these using environment variables:
+# 
+# export DIGITALOCEAN_API_TOKEN=<_your_API_token_>
+# export PMM_ADMIN_PASSWORD=<_your_PMM_password_>
+""".format(getPublicIPv4())
+)
+
+
+def main(arguments):
+
+    printBanner()
+    
+    digitalocean_api_token = getAPIToken()
+    pmm_admin_password = getPMMAdminPassword()
+    pmm = PmmServer(serverAdminPassword=pmm_admin_password)
+    
+    instanceProperties = getDBInstances(digitalocean_api_token)
+    eligibleInstances = [ DbaasInstance(i, pmm) for i in instanceProperties if i['engine'] in ['mysql']]
+    selectedInstances = promptForDBSelection(eligibleInstances)
+    for instance in selectedInstances:
+        if instance.monitored:
+            print('Instance "{}" is already monitored by PMM.'.format(instance.name))
+            continue
+        if instance.engine == 'mysql':
+            pmm.addMySQL(instance)
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv[1:]))

--- a/packer/pmm2.json
+++ b/packer/pmm2.json
@@ -69,7 +69,7 @@
             "ssh_username": "root",
             "image": "centos-7-x64",
             "region": "nyc3",
-            "size": "s-6vcpu-16gb",
+            "size": "s-4vcpu-8gb",
             "snapshot_name": "PMM2 Server [{{isotime \"2006-01-02 1504\"}}]",
             "ssh_clear_authorized_keys": "true"
         }

--- a/packer/pmm2.json
+++ b/packer/pmm2.json
@@ -117,6 +117,14 @@
             "inline": [
                 "sudo bats /tmp/bats/*.bats"
             ]
+        },
+        {
+            "type": "shell",
+            "only": ["digitalocean"],
+            "inline": [
+                "curl -s https://raw.githubusercontent.com/digitalocean/marketplace-partners/master/scripts/img_check.sh -o img_check.sh",
+                "sudo bash ./img_check.sh"
+            ]
         }
     ],
     "post-processors": [

--- a/packer/pmm2.json
+++ b/packer/pmm2.json
@@ -85,7 +85,7 @@
         {
             "type": "ansible-local",
             "playbook_file": "ansible/pmm2/main.yml",
-            "extra_arguments": ["-v", "--extra-vars", "pmm2_server_repo=laboratory", "--extra-vars", "single_disk={{user `single_disk`}}"],
+            "extra_arguments": ["-v", "--extra-vars", "pmm2_server_repo=release", "--extra-vars", "single_disk={{user `single_disk`}}"],
             "role_paths": [
                 "ansible/roles/cloud-node",
                 "ansible/roles/nginx-init",

--- a/packer/pmm2.json
+++ b/packer/pmm2.json
@@ -1,4 +1,7 @@
 {
+    "variables": {
+      "single_disk": "false"
+    },
     "builders": [{
             "type": "amazon-ebs",
             "ami_name": "PMM2 Server [{{isotime \"2006-01-02 1504\"}}]",
@@ -60,6 +63,15 @@
                 ["storagectl", "{{.Name}}", "--name", "SCSI Controller", "--add", "scsi", "--controller", "LSILogic"],
                 ["storageattach", "{{.Name}}", "--storagectl", "SCSI Controller", "--port", "1", "--type", "hdd", "--medium", "/tmp/{{.Name}}-disk2.vmdk"]
             ]
+        },
+        {
+            "type": "digitalocean",
+            "ssh_username": "root",
+            "image": "centos-7-x64",
+            "region": "nyc3",
+            "size": "s-6vcpu-16gb",
+            "snapshot_name": "PMM2 Server [{{isotime \"2006-01-02 1504\"}}]",
+            "ssh_clear_authorized_keys": "true"
         }
     ],
     "provisioners": [{
@@ -73,7 +85,7 @@
         {
             "type": "ansible-local",
             "playbook_file": "ansible/pmm2/main.yml",
-            "extra_arguments": ["-v", "--extra-vars", "pmm2_server_repo=laboratory"],
+            "extra_arguments": ["-v", "--extra-vars", "pmm2_server_repo=laboratory", "--extra-vars", "single_disk={{user `single_disk`}}"],
             "role_paths": [
                 "ansible/roles/cloud-node",
                 "ansible/roles/nginx-init",

--- a/packer/pmm2.json
+++ b/packer/pmm2.json
@@ -119,6 +119,12 @@
             ]
         },
         {
+            "type": "file",
+            "only": ["digitalocean"],
+            "destination": "/home/admin/digitalocean_add_dbaas",
+            "source": "files/digitalocean/digitalocean_add_dbaas.py"
+        },
+        {
             "type": "shell",
             "only": ["digitalocean"],
             "inline": [


### PR DESCRIPTION
This adds a Packer target for building a DigitalOcean image for the purpose of listing in DigitalOcean's Marketplace. 

Due to the lack of a DigitalOcean-equivalent to the `amazon-ebs` Packer builder, it was necessary to build the DigitalOcean image on. single volume (instance storage). To this end, a `single_disk` variable was added to the `lvm-init` role to gate tasks that don't apply to a single-volume install.

A helper script, `digitalocean_add_dbaas`, is included in the admin user's home directory on DigitalOcean images to assist in adding DigitalOcean DBaaS MySQL instances to PMM. 